### PR TITLE
Add missing deployment object in the body request

### DIFF
--- a/src/commands/deployment_marker.yml
+++ b/src/commands/deployment_marker.yml
@@ -16,9 +16,11 @@ steps:
             -H "Content-Type: application/json" \
             -i \
             -d \
-            "{
-              \"revision\": \"${CIRCLE_SHA1}\",
-              \"changelog\": \"${COMMIT_MESSAGE}\",
-              \"description\": \"${DESCRIPTION}\",
-              \"user\": \"${CIRCLE_USERNAME}\"
+            "{ 
+                \"deployment\": {
+                  \"revision\": \"${CIRCLE_SHA1}\",
+                  \"changelog\": \"${COMMIT_MESSAGE}\",
+                  \"description\": \"${DESCRIPTION}\",
+                  \"user\": \"${CIRCLE_USERNAME}\"
+                }
             }"


### PR DESCRIPTION

Without the parameters being wrapped in "deployment", NewRelic API responds with an error
```
'{"error":{"title":"missing parameter: deployment"}}'
```
Here is more discussion:
https://discuss.newrelic.com/t/missing-parameter-deployment-for-deployments-json-solved/104716

This PR should fix the problem